### PR TITLE
Add SDXL prompt agent example

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -30,6 +30,10 @@ This folder contains comprehensive examples of PydanticAI Agents working with yo
 - Context sharing between tools
 - Interactive assistant interface
 
+### 5. `sdxl_prompt_agent.py` - SDXL Prompt Generator
+- Generates Stable Diffusion XL prompts
+- Returns positive and negative prompts using structured output
+
 ## How to Run
 
 Make sure LM Studio is running with your model loaded, then:
@@ -46,6 +50,8 @@ python advanced_agent.py
 
 # Multi-tool assistant
 python multi_tool_agent.py
+# SDXL prompt generator
+python sdxl_prompt_agent.py
 ```
 
 ## Key Concepts Demonstrated

--- a/chat/sdxl_prompt_agent.py
+++ b/chat/sdxl_prompt_agent.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+SDXL Prompt Agent
+Generate positive and negative prompts for Stable Diffusion XL.
+"""
+from pydantic import BaseModel
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+
+class SDXLPrompts(BaseModel):
+    """Structured output for SDXL prompts."""
+    prompt: str
+    negative_prompt: str
+
+
+# Configure the local model (LM Studio)
+model = OpenAIModel(
+    'ibm/granite-3.2-8b',
+    provider=OpenAIProvider(
+        base_url='http://localhost:1234/v1',
+        api_key='lm-studio'
+    ),
+)
+
+# Create the SDXL prompt agent
+sdxl_agent = Agent(
+    model,
+    output_type=SDXLPrompts,
+    system_prompt=(
+        "You are an expert Stable Diffusion XL prompt engineer. "
+        "Given a user description, craft a vivid positive prompt and a concise "
+        "negative prompt. Always respond with JSON using the fields 'prompt' "
+        "and 'negative_prompt'."
+    ),
+)
+
+
+def interactive_prompting() -> None:
+    """Interactive prompt generation loop."""
+    print("\U0001f3a8 SDXL Prompt Generator")
+    print("Type 'quit' to exit")
+    print("-" * 30)
+
+    while True:
+        user_input = input("\nDescribe the image: ").strip()
+
+        if user_input.lower() in {'quit', 'exit', 'q'}:
+            print("Goodbye! \U0001f5bc")
+            break
+
+        if not user_input:
+            continue
+
+        try:
+            result = sdxl_agent.run_sync(user_input)
+            print(f"\nPositive: {result.output.prompt}")
+            print(f"Negative: {result.output.negative_prompt}")
+        except Exception as exc:
+            print(f"Error: {exc}")
+
+
+if __name__ == '__main__':
+    interactive_prompting()

--- a/chat/test_agents.py
+++ b/chat/test_agents.py
@@ -22,6 +22,7 @@ def main():
         'simple_agent.py',
         'roulette_agent.py', 
         'advanced_agent.py',
+        'sdxl_prompt_agent.py',
         'multi_tool_agent.py'
     ]
     
@@ -44,6 +45,7 @@ def main():
     print("\n📋 Usage:")
     print("python simple_agent.py      # Basic agent chat")
     print("python roulette_agent.py    # Roulette game with tools")
+    print("python sdxl_prompt_agent.py  # SDXL prompt generator")
     print("python advanced_agent.py    # All run methods demo")
     print("python multi_tool_agent.py  # Multi-tool assistant")
 


### PR DESCRIPTION
## Summary
- add `sdxl_prompt_agent.py` for generating SDXL prompts
- document new script in README
- include new script in test suite
- fix deprecation warning by using `result.output`

## Testing
- `python chat/test_agents.py`


------
https://chatgpt.com/codex/tasks/task_e_6858995ca688832fae662c97a5101995